### PR TITLE
fix: improve the script's resilience when the GitHub API returns an error

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,1 +1,11 @@
 export const presentState = (state: string): string => state.replace('_', ' ').toLowerCase();
+
+export const serializeError = (error: any): string => {
+    if (typeof error === 'string') {
+        return error;
+    } else {
+        return JSON.stringify(error);
+    }
+};
+
+export const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms));


### PR DESCRIPTION
This improves the resilient of the script errors returned by the GitHub API, aiming to log and retry rather than explode the script.

Fixes #10 and #11.