### PR TITLE
feat: add `--since` option to only show migrations queued after a certain date or datetime

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -2,6 +2,7 @@ export interface Opts {
   githubToken?: string;
   organization: string;
   intervalInSeconds: number;
+  since?: string;
 }
 
 export interface RepositoryMigration {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -9,3 +9,23 @@ export const serializeError = (e: unknown): string => {
   if (e instanceof GraphqlResponseError) return e.message;
   return JSON.stringify(e);
 }
+
+const isValidDate = (date: unknown): boolean => date instanceof Date && !isNaN(date.getTime());
+
+export const parseSince = (since: string): Date => {
+  if (since === 'now') {
+    return new Date();
+  } else if (since.match(/^\d{4}-\d{2}-\d{2}$/)) {
+    // Passing a date without time will default to midnight UTC, when we want to use
+    // local time if a specific time zone is not specified
+    return new Date(`${since}T00:00:00`);
+  } else {
+    const dateFromInput = new Date(since);
+
+    if (isValidDate(dateFromInput)) {
+      return new Date(since);
+    } else {
+      throw 'The provided date seems to be invalid. Please provide a valid ISO 8601 date or datetime, or use "now" to use the current date.';
+    }
+  }
+};


### PR DESCRIPTION
This adds a new `--since` command line option, which can be used to filter the UI to only show migrations queued on or after a certain date or datetime. The value `now` is also supported to refer to the current datetime.